### PR TITLE
Move ACME before account creation

### DIFF
--- a/Client/Pages/Install/InstallIndex.razor
+++ b/Client/Pages/Install/InstallIndex.razor
@@ -1,4 +1,5 @@
 @page "/install"
+@page "/install/{Secret}"
 
 @implements IDisposable
 
@@ -29,28 +30,51 @@
 </div>
 
 @code {
+    [Parameter]
+    public string? Secret { get; set; }
+
     private InstallStateMachine InstallStateMachine = null!;
     private IStep? CurrentStep;
-    private string? _authToken;
     private bool _installIsPossible = true;
 
     protected override void OnInitialized() 
     {
         InstallStateMachine = new InstallStateMachine();
-        InstallStateMachine.Initialize();
+        if(Secret == null) 
+        {
+            InstallStateMachine.Initialize();
+        }
+        else
+        {
+            InstallStateMachine.ResumeFromHttps();
+        }
         InstallStateMachine.OnChange += StateHasChanged;
         SetCurrentStep();
     }
 
     protected override async Task OnInitializedAsync() 
     {
-        StartSetupReply reply = await InstallClient.StartSetupAsync(new Google.Protobuf.WellKnownTypes.Empty{});
-        _authToken = reply.AuthToken;
-
-        if (!reply.Success) 
+        if (Secret == null)
         {
-            _installIsPossible = false;
-            return;
+            StartSetupReply reply = await InstallClient.StartSetupAsync(new Google.Protobuf.WellKnownTypes.Empty{});
+            InstallStateMachine.AuthToken = reply.AuthToken;
+
+            if (!reply.Success) 
+            {
+                _installIsPossible = false;
+            }
+        }
+        else
+        {
+            ChangeInstallTokenReply reply = await InstallClient.ChangeInstallTokenAsync(new ChangeInstallTokenRequest{
+                AuthToken = Secret
+            });
+
+            InstallStateMachine.AuthToken = reply.AuthToken;
+            if(InstallStateMachine.AuthToken == "")
+            {
+                _installIsPossible = false;
+            }
         }
     }
 
@@ -77,7 +101,7 @@
         InstallStateMachine.FinishStep(CurrentStep);
 
         SetupInstanceRequest request = InstallStateMachine.GetSetupInstanceRequest();
-        request.AuthToken = _authToken;
+        request.AuthToken = InstallStateMachine.AuthToken;
         SetupInstanceReply reply = await InstallClient.SetupInstanceAsync(request);
 
         if(reply.Succeeded) 
@@ -85,7 +109,7 @@
             ((Util.AuthStateProvider) AuthenticationStateProvider).StateHasChanged();
             NavigationManager.NavigateTo("/");
         } 
-        else 
+        else
         {
             _installIsPossible = false;        
         }

--- a/Client/Pages/Install/InstallStateMachine.cs
+++ b/Client/Pages/Install/InstallStateMachine.cs
@@ -12,10 +12,18 @@ namespace AuthServer.Client.Pages.Install
         private IStep? PreviousStep;
         private IStep? NextStep;
         private SetupInstanceRequest _setupInstanceRequest = new SetupInstanceRequest();
+        public string? AuthToken;
+        public string? DomainName;
+        public string? AcmeContactEmailAddress;
 
-        internal void Initialize()
+        public void Initialize()
         {
             _currentStep = new InitialSetupStep();
+        }
+
+        public void ResumeFromHttps()
+        {
+            _currentStep = new EmailSelectionStep();
         }
 
         internal SetupInstanceRequest GetSetupInstanceRequest()
@@ -38,13 +46,8 @@ namespace AuthServer.Client.Pages.Install
                     };
                     break;
                 case ConfigureLetsEncryptCertificateStep tlsStep:
-                    _setupInstanceRequest.TlsData = new SetupTlsData
-                    {
-                        Domain = tlsStep.letsEncryptCertificateSettings.DomainName,
-                        ContactEmail = tlsStep.letsEncryptCertificateSettings.Email,
-                    };
-
-                    _setupInstanceRequest.PrimaryDomain = tlsStep.letsEncryptCertificateSettings.DomainName;
+                    DomainName = tlsStep.letsEncryptCertificateSettings.DomainName;
+                    AcmeContactEmailAddress = tlsStep.letsEncryptCertificateSettings.Email;
                     break;
                 case AccountCreationStep accountCreationStep:
                     _setupInstanceRequest.AccountData = new SetupAccountData

--- a/Client/Pages/Install/Steps/ConfigureLetsEncryptCertificateStep.razor
+++ b/Client/Pages/Install/Steps/ConfigureLetsEncryptCertificateStep.razor
@@ -45,7 +45,7 @@
     {
         if (valid)
         {
-            StateMachine.SetNextStep(new EmailSelectionStep());
+            StateMachine.SetNextStep(new RedirectionToSecurePageStep());
         }
         else 
         {

--- a/Client/Pages/Install/Steps/RedirectionToSecurePageStep.razor
+++ b/Client/Pages/Install/Steps/RedirectionToSecurePageStep.razor
@@ -1,0 +1,54 @@
+@implements IStep
+
+@inject AuthServer.Shared.Install.InstallClient InstallClient
+@inject NavigationManager NavigationManager
+
+@using AuthServer.Shared
+@using System.Web
+
+<h1>Configuring certificates</h1>
+
+<p>Gatekeeper is currently configuring the requested HTTPS certificates. Upon completion, you will be automatically redirected.</p>
+
+@code {
+    [Parameter]
+    public InstallStateMachine StateMachine { get; set; }
+
+    protected override void OnInitialized() 
+    {
+        StateMachine.SetNextStep(null);
+        StateMachine.SetPreviousStep(null);
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RequestTlsCertificate();
+        await Task.Delay(5000);
+        await CheckCertificateValidityLoop();
+    }
+
+    private async Task RequestTlsCertificate()
+    {
+        await InstallClient.IssueTlsCertificateAsync(new IssueTlsCertificateRequest{
+            AuthToken = StateMachine.AuthToken,
+            Domain = StateMachine.DomainName,
+            ContactEmail = StateMachine.AcmeContactEmailAddress,
+        });
+    }
+
+    private async Task CheckCertificateValidityLoop()
+    {
+        IsTlsCertificateSetupReply reply = await InstallClient.IsTlsCertificateSetupAsync(new IsTlsCertificateSetupRequest {
+            AuthToken = StateMachine.AuthToken,
+            Domain = StateMachine.DomainName,
+        });
+
+        if(reply.Success)
+        {
+            NavigationManager.NavigateTo("https://" + StateMachine.DomainName + "/install/" + HttpUtility.UrlPathEncode(StateMachine.AuthToken));
+        } else {
+            await Task.Delay(5000);
+            await CheckCertificateValidityLoop();
+        }
+    }
+}

--- a/Shared/Protos/install.proto
+++ b/Shared/Protos/install.proto
@@ -9,6 +9,32 @@ service Install {
   rpc SetupInstance (SetupInstanceRequest) returns (SetupInstanceReply);
   rpc StartSetup (google.protobuf.Empty) returns (StartSetupReply);
   rpc CheckIsInstalled (google.protobuf.Empty) returns (CheckIsInstalledReply);
+  rpc IssueTlsCertificate (IssueTlsCertificateRequest) returns (google.protobuf.Empty);
+  rpc IsTlsCertificateSetup (IsTlsCertificateSetupRequest) returns (IsTlsCertificateSetupReply);
+  rpc ChangeInstallToken (ChangeInstallTokenRequest) returns (ChangeInstallTokenReply);
+}
+
+message ChangeInstallTokenRequest {
+  string auth_token = 1;
+}
+
+message ChangeInstallTokenReply {
+  string auth_token = 1;
+}
+
+message IsTlsCertificateSetupRequest {
+  string domain = 1;
+  string auth_token = 2;
+}
+
+message IsTlsCertificateSetupReply {
+  bool success = 1;
+}
+
+message IssueTlsCertificateRequest {
+  string domain = 1;
+  string contact_email = 2;
+  string auth_token = 3;
 }
 
 message CheckIsInstalledReply {
@@ -19,8 +45,6 @@ message SetupInstanceRequest {
   SetupSmtpData smtp_settings = 1;
   SetupAccountData account_data = 2;
   string auth_token = 3;
-  SetupTlsData tls_data = 4;
-  google.protobuf.StringValue primary_domain = 5;
 }
 
 message StartSetupReply {
@@ -28,10 +52,6 @@ message StartSetupReply {
   google.protobuf.StringValue auth_token = 2;
 }
 
-message SetupTlsData {
-  string domain = 1;
-  string contact_email = 2;
-}
 
 message SetupSmtpData {
   string username = 1;


### PR DESCRIPTION
This moves the ACME step before account creation and will users redirect to the HTTPS version once defined.