### PR TITLE
Implement device cookie

### DIFF
--- a/Gatekeeper.Server.Web/Migrations/20210126191612_AddDeviceCookieToDatabase.Designer.cs
+++ b/Gatekeeper.Server.Web/Migrations/20210126191612_AddDeviceCookieToDatabase.Designer.cs
@@ -5,6 +5,7 @@ using System.Net;
 using AuthServer.Server.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,10 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace AuthServer.Server.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20210126191612_AddDeviceCookieToDatabase")]
+    partial class AddDeviceCookieToDatabase
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Gatekeeper.Server.Web/Migrations/20210126191612_AddDeviceCookieToDatabase.cs
+++ b/Gatekeeper.Server.Web/Migrations/20210126191612_AddDeviceCookieToDatabase.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace AuthServer.Server.Migrations
+{
+    public partial class AddDeviceCookieToDatabase : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DELETE FROM \"AuthSessions\"");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "DeviceCookieId",
+                table: "AuthSessions",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"));
+
+            migrationBuilder.CreateTable(
+                name: "DeviceCookies",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DeviceCookies", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AuthSessions_DeviceCookieId",
+                table: "AuthSessions",
+                column: "DeviceCookieId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_AuthSessions_DeviceCookies_DeviceCookieId",
+                table: "AuthSessions",
+                column: "DeviceCookieId",
+                principalTable: "DeviceCookies",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_AuthSessions_DeviceCookies_DeviceCookieId",
+                table: "AuthSessions");
+
+            migrationBuilder.DropTable(
+                name: "DeviceCookies");
+
+            migrationBuilder.DropIndex(
+                name: "IX_AuthSessions_DeviceCookieId",
+                table: "AuthSessions");
+
+            migrationBuilder.DropColumn(
+                name: "DeviceCookieId",
+                table: "AuthSessions");
+        }
+    }
+}

--- a/Gatekeeper.Server.Web/Models/AuthDbContext.cs
+++ b/Gatekeeper.Server.Web/Models/AuthDbContext.cs
@@ -42,6 +42,7 @@ namespace AuthServer.Server.Models
         public DbSet<AuthSessionIp> AuthSessionIps { get; set; } = null!;
         public DbSet<SystemSecurityAlert> SystemSecurityAlerts { get; set; } = null!;
         public DbSet<UserSecurityAlert> UserSecurityAlerts { get; set; } = null!;
+        public DbSet<DeviceCookie> DeviceCookies { get; set; } = null!;
     }
 
     public class SystemSetting
@@ -196,6 +197,13 @@ namespace AuthServer.Server.Models
         public string? UserAgent { get; set; }
         [Column(TypeName = "jsonb")]
         public DeviceInformation? DeviceInfo { get; set; }
+        public DeviceCookie DeviceCookie { get; set; } = null!;
+    }
+
+    public class DeviceCookie
+    {
+        public Guid Id { get; set; }
+        public ICollection<AuthSession> AuthSessions { get; set; } = null!;
     }
 
     public class DeviceInformation

--- a/Gatekeeper.Server.Web/Services/Authentication/DeviceCookie/DeviceCookieManager.cs
+++ b/Gatekeeper.Server.Web/Services/Authentication/DeviceCookie/DeviceCookieManager.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading.Tasks;
+using AuthServer.Server.Models;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+
+namespace Gatekeeper.Server.Web.Services.Authentication.DeviceCookie
+{
+    public class DeviceCookieManager
+    {
+        public const string DEVICE_COOKIE_STRING = "DeviceId";
+        private readonly AuthDbContext _authDbContext;
+        private IDataProtector _deviceCookieProtector;
+
+        public DeviceCookieManager(
+            AuthDbContext authDbContext,
+            IDataProtectionProvider dataProtectionProvider)
+        {
+            _authDbContext = authDbContext;
+            _deviceCookieProtector = dataProtectionProvider.CreateProtector("DeviceCookieProtector");
+        }
+
+        public async Task<AuthServer.Server.Models.DeviceCookie?> GetDeviceCookieAsync(EncryptedDeviceCookie encryptedDeviceCookie)
+        {
+            string value = _deviceCookieProtector.Unprotect(encryptedDeviceCookie.EncryptedValue);
+            bool isGuid = Guid.TryParse(value, out var deviceGuid);
+            if (isGuid)
+            {
+                AuthServer.Server.Models.DeviceCookie? deviceCookie = await _authDbContext.DeviceCookies
+                    .SingleOrDefaultAsync(d => d.Id == deviceGuid);
+
+                return deviceCookie;
+            }
+
+            return null;
+        }
+
+        public AuthServer.Server.Models.DeviceCookie BuildNewDeviceCookie()
+        {
+            return new AuthServer.Server.Models.DeviceCookie { };
+        }
+
+        public EncryptedDeviceCookie GetEncryptedDeviceCookie(AuthServer.Server.Models.DeviceCookie deviceCookie)
+        {
+            string value = _deviceCookieProtector.Protect(deviceCookie.Id.ToString());
+
+            return new EncryptedDeviceCookie(value);
+        }
+    }
+}

--- a/Gatekeeper.Server.Web/Services/Authentication/DeviceCookie/EncryptedDeviceCookie.cs
+++ b/Gatekeeper.Server.Web/Services/Authentication/DeviceCookie/EncryptedDeviceCookie.cs
@@ -1,0 +1,12 @@
+namespace Gatekeeper.Server.Web.Services.Authentication.DeviceCookie
+{
+    public class EncryptedDeviceCookie
+    {
+        public readonly string EncryptedValue;
+
+        public EncryptedDeviceCookie(string encryptedCookieValue)
+        {
+            EncryptedValue = encryptedCookieValue;
+        }
+    }
+}

--- a/Gatekeeper.Server.Web/Startup.cs
+++ b/Gatekeeper.Server.Web/Startup.cs
@@ -44,6 +44,7 @@ using Gatekeeper.Server.Web.Services.Alerts;
 using Npgsql;
 using System.Linq;
 using Gatekeeper.Server.Web.GRPC.Security;
+using Gatekeeper.Server.Web.Services.Authentication.DeviceCookie;
 
 namespace AuthServer.Server
 {
@@ -134,6 +135,7 @@ namespace AuthServer.Server
             // Authentication
             services.AddScoped<SessionManager>();
             services.AddScoped<BruteforceManager>();
+            services.AddScoped<DeviceCookieManager>();
 
             // Crypto
             services.AddScoped<SecureRandom>();


### PR DESCRIPTION
This stores a permanent device cookie on each login. Trusted devices will be exempt from the enforced ratelimiting.